### PR TITLE
organize-webAPI

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -3,7 +3,7 @@ import config from './config'
 import { getAuthToken } from './utils'
 
 const instance = axios.create({
-  baseURL: config.apiHost,
+  baseURL: config.apiHost
 })
 
 instance.interceptors.request.use((config) => {
@@ -15,79 +15,81 @@ instance.interceptors.request.use((config) => {
 
 // user
 export const userLogin = (payload) => instance.post('/users/login', payload)
-export const userRegister = (payload) =>
-  instance.post('/users/register', payload)
-export const getAllUsers = (adminToken, params) =>
-  instance.get('/users' + params, { headers: { Authorization: `Bearer ${adminToken}` } })
+export const userRegister = (payload) => instance.post('/users/register', payload)
+export const getAllUsers = (params) => instance.get('/users' + params)
 
 // trails
+// get 相關
 export const getTrails = (params) => instance.get('/trails/' + params)
-export const getTrailArticles = (trailID, params) =>
-  instance.get('/trails/' + trailID + '/articles' + params)
 export const getHotTrails = () => instance.get('/trails/hot/5')
+export const getTrailsCondition = () => axios.get(config.tfrHost)
+
+// 刪除復原相關
 export const deleteTrail = (trailID) => instance.delete('/trails/' + trailID)
 export const getDeletedTrail = (params) => instance.get('/trails/deleted' + params)
 export const recoverTrail = (trailID) => instance.patch('/trails/deleted/' + trailID)
-export const getTrailsCondition = () => axios.get(config.tfrHost)
+
+// 新增編輯相關
 export const postTrails = (data) => instance.post('/trails', data)
+
+// 步道評論CRUD
+export const apiComments = (articleId) => instance.get(`/trails/${articleId}/comments`)
+export const apiCommentsPost = (articleId, authorId, content) =>
+  instance.post(`/trails/${articleId}/comments`, {
+    author_id: authorId,
+    content
+  })
+export const apiCommentsPatch = (articleId, messageId, content) =>
+  instance.patch(`/trails/${articleId}/comments/${messageId}`, {
+    content
+  })
+export const apiCommentsDelete = (articleId, messageId) =>
+  instance.delete(`/trails/${articleId}/comments/${messageId}`)
 
 
 // articles
+// get 相關
 export const getArticles = (params) => instance.get('/articles/' + params)
-export const deleteArticle = (adminToken, articleID) =>
-  instance.delete('/articles/' + articleID, { headers: { Authorization: `Bearer ${adminToken}` } })
+export const apiArticles = () => instance.get('/articles')
+export const apiArticle = (articleId) => instance.get(`/articles/${articleId}`)
+export const apiArticlesHot = () => instance.get('/articles/hot')
+export const getTrailArticles = (trailID, params) =>
+  instance.get('/trails/' + trailID + '/articles' + params)
+export const getArticlesUnderTrail = (TrailId) => instance.get('/trails/' + TrailId + '/articles')
+
+// 刪除復原相關
+export const deleteArticle = (articleID) => instance.delete('/articles/' + articleID)
 export const getDeletedArticle = (params) => instance.get('/articles/deleted' + params)
 export const recoverArticle = (articleID) => instance.patch('/articles/deleted/' + articleID)
 
-// export const getArticles = () => instance.get('/articles')
+// 新增編輯相關
+export const postArticles = (data) => instance.post('/articles', data)
 
-export const apiArticle = (articleId) => instance.get(`/articles/${articleId}`)
-export const apiMessages = (articleId) =>
-  instance.get(`/articles/${articleId}/messages`)
+// 心得評論CRUD
+export const apiMessages = (articleId) => instance.get(`/articles/${articleId}/messages`)
 export const apiMessagesPost = (articleId, authorId, content) =>
   instance.post(`/articles/${articleId}/messages`, {
     author_id: authorId,
-    content,
+    content
   })
 export const apiMessagesPatch = (articleId, messageId, content) =>
   instance.patch(`/articles/${articleId}/messages/${messageId}`, {
-    content,
+    content
   })
 export const apiMessagesDelete = (articleId, messageId) =>
   instance.delete(`/articles/${articleId}/messages/${messageId}`)
 
-export const apiArticleGetLike = (userId) =>
-  instance.get(`users/${userId}/liked-articles`)
+// 心得按讚關聯
+export const apiArticleGetLike = (userId) => instance.get(`users/${userId}/liked-articles`)
 export const apiArticlePostLike = (userId, articleId) =>
   instance.post(`users/${userId}/liked-articles`, {
-    article_id: articleId,
+    article_id: articleId
   })
 export const apiArticleRemoveLike = (userId, articleId) =>
   instance.delete(`users/${userId}/liked-articles/${articleId}`)
 
-//步道相關 api
 
-export const apiComments = (articleId) =>
-  instance.get(`/trails/${articleId}/comments`)
-export const apiCommentsPost = (articleId, authorId, content) =>
-  instance.post(`/trails/${articleId}/comments`, {
-    author_id: authorId,
-    content,
-  })
-export const apiCommentsPatch = (articleId, messageId, content) =>
-  instance.patch(`/trails/${articleId}/comments/${messageId}`, {
-    content,
-  })
-export const apiCommentsDelete = (articleId, messageId) =>
-  instance.delete(`/trails/${articleId}/comments/${messageId}`)
-export const getArticlesUnderTrail = (TrailId) =>
-  instance.get('/trails/' + TrailId + '/articles')
-export const postArticles = (data) => instance.post('/articles', data)
-
-// 文章相關的 api
-export const apiArticlesHot = () => instance.get('/articles/hot')
-export const apiArticles = () => instance.get('/articles')
-
+// 不確定這支的分類
 export const apiArticlesOptions = (limit, tags, offset, search) => {
   let url = `/articles?`
   if (limit) {
@@ -105,3 +107,5 @@ export const apiArticlesOptions = (limit, tags, offset, search) => {
   return instance.get(url)
 }
 
+
+// 其他 IMGUR WEATHER 等等

--- a/src/components/adminSystem/ArticlesManagement.js
+++ b/src/components/adminSystem/ArticlesManagement.js
@@ -221,7 +221,7 @@ function ArticlesManagement({ recycle, setRecycle }) {
 
   const handleDelete = (articleID, articleTitle) => {
     if (!userInfo || userInfo.role !== 'admin') return
-    deleteArticle(adminToken, articleID).then()
+    deleteArticle(articleID).then()
     alert(`刪除 ${articleTitle}`)
     setArticles(articles.filter((article) => article.article_id !== articleID))
   }

--- a/src/components/adminSystem/UsersManagement.js
+++ b/src/components/adminSystem/UsersManagement.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext} from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import styled from 'styled-components'
 import { COLOR, FONT, RADIUS, MEDIA_QUERY } from '../../constants/style'
 import { ReactComponent as SearchIcon } from '../../icons/search.svg'
@@ -128,7 +128,7 @@ function UsersManagement() {
 
   console.log('adminToken', adminToken)
   useEffect(() => {
-    getAllUsers(adminToken, `?offset=${(page - 1) * 20}`)
+    getAllUsers(`?offset=${(page - 1) * 20}`)
       .then((res) => {
         setUsers(res.data.data.users)
       })


### PR DESCRIPTION
除了我自己的幾支需要權限token有修改外，其他API只有做順序上的調整

我原本寫法，使在原頁面拿到token再將參數傳進來
但是 yu 提供的新方法什麼都不用做，非常方便 

目前想法編排是這樣，
分三大區，user trail 跟 article
這三大區裡面再分小區（中文註解之後會刪掉 目前好讀用）
如抓取，刪除、新增編輯、留言評論CRUD、收藏按讚關聯等
