### PR TITLE
fix login 401 err handling

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -22,6 +22,8 @@ instance.interceptors.response.use(
   (error) => {
     if (error.response.status === 401) {
       const refreshTokenUrl = '/users/refresh'
+      if (error.config.url === '/users/login')
+        return swal('登入失敗', '帳號或密碼輸入錯誤', 'error')
       if (error.config.url !== refreshTokenUrl) {
         const originalRequest = error.config
         return refreshAccessToken()

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -5,7 +5,7 @@ import { getAuthToken } from './utils'
 import { setAuthToken } from './utils'
 
 const instance = axios.create({
-  baseURL: config.apiHost,
+  baseURL: config.apiHost2,
 })
 
 instance.interceptors.request.use((config) => {

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -34,7 +34,8 @@ export default function useLogin() {
     setIsLoadingLogin(true)
     userLogin(loginInfo)
       .then((res) => {
-        if (res.data.success) {
+        if (!res) return setIsLoadingLogin(false)
+        if (res && res.data.success) {
           setAuthToken(res.data.data.token)
           setUserInfo(jwt_decode(res.data.data.token))
           setIsLoadingLogin(false)
@@ -43,10 +44,11 @@ export default function useLogin() {
             button: '關閉',
           })
           history.push('/')
+          return
         }
       })
       .catch((err) => {
-        setErrMsg(err.response.data.message)
+        if (err.response) setErrMsg(err.response.data.message)
         setIsLoadingLogin(false)
       })
   }

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -17,23 +17,22 @@ export default function useLogout() {
       buttons: ['取消', '確定'],
       dangerMode: true,
     }).then((willLogout) => {
-      if (willLogout) {
-        userLogout()
-          .then((res) => {
-            if (res.data.success) {
-              setAuthToken('')
-              setUserInfo(null)
-              swal('登出成功！', {
-                icon: 'success',
-                button: '關閉',
-              })
-              if (location.pathname !== '/') return history.push('/')
-            }
-          })
-          .catch(() => {
-            swal('Oh 不！', '請求失敗！請稍候再試一次，或者聯繫我們。', 'error')
-          })
-      }
+      if (!willLogout) return
+      userLogout()
+        .then((res) => {
+          if (res.data.success) {
+            setAuthToken('')
+            setUserInfo(null)
+            swal('登出成功！', {
+              icon: 'success',
+              button: '關閉',
+            })
+            if (location.pathname !== '/') return history.push('/')
+          }
+        })
+        .catch(() => {
+          swal('Oh 不！', '請求失敗！請稍候再試一次，或者聯繫我們。', 'error')
+        })
     })
   }
 

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -1,4 +1,5 @@
 import { useInput } from './useInput'
+import { useCallback } from 'react'
 
 export default function useSearch() {
   const {
@@ -6,9 +7,10 @@ export default function useSearch() {
     setInputValue: setKeyWord,
     handleInputChange: handleKeyWordChange,
   } = useInput()
-  const handleKeyWordDelete = () => {
+  const handleKeyWordDelete = useCallback(() => {
     setKeyWord('')
-  }
+  }, [setKeyWord])
+
   return {
     keyWord,
     handleKeyWordChange,

--- a/src/hooks/useTrialFilters.js
+++ b/src/hooks/useTrialFilters.js
@@ -1,23 +1,28 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { parameterMap } from '../constants/paramsMap'
 
 export default function useTrailFilters() {
   const [checkedOptions, setCheckedOptions] = useState([])
 
-  const handleFilterTrails = (e) => {
-    if (!e.target.getAttribute('filter')) return
-    let targetOptionType = e.target.getAttribute('filter')
-    if (Object.keys(parameterMap[targetOptionType]).indexOf(e.target.name) < 0)
-      return
-    let targetOption = parameterMap[targetOptionType][e.target.name]
-    if (checkedOptions.indexOf(targetOption) >= 0) {
-      return setCheckedOptions(
-        checkedOptions.filter((option) => option !== targetOption)
+  const handleFilterTrails = useCallback(
+    (e) => {
+      if (!e.target.getAttribute('filter')) return
+      let targetOptionType = e.target.getAttribute('filter')
+      if (
+        Object.keys(parameterMap[targetOptionType]).indexOf(e.target.name) < 0
       )
-    }
+        return
+      let targetOption = parameterMap[targetOptionType][e.target.name]
+      if (checkedOptions.indexOf(targetOption) >= 0) {
+        return setCheckedOptions(
+          checkedOptions.filter((option) => option !== targetOption)
+        )
+      }
 
-    setCheckedOptions([...checkedOptions, targetOption])
-  }
+      setCheckedOptions([...checkedOptions, targetOption])
+    },
+    [checkedOptions]
+  )
 
   return {
     checkedOptions,

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -61,12 +61,15 @@ const TrialTitleWrapper = styled.div`
 
 const TrialTitleName = styled(Link)`
   font-size: ${FONT.lg};
-  color: black;
   border-left: 20px solid ${COLOR.brown};
   padding-left: 10px;
+  color: black;
   ${MEDIA_QUERY.lg} {
     border-left: none;
     font-size: ${FONT.logo};
+  }
+  &:hover {
+    color: ${COLOR.gray};
   }
 `
 const TrialTitleLocation = styled.div`
@@ -117,7 +120,7 @@ function HomePage() {
 
   useEffect(() => {
     setIsLoading(true)
-    getTrailArticles(1, '?limit=100')
+    getTrailArticles(1, '')
       .then((res) => {
         if (res.data.success) {
           setActiveTrailArticles({


### PR DESCRIPTION
fix:
login 使用者帳號密碼輸入錯誤的 401 處理。
之前的處理方式是跟 jwt token 過期走同樣流程，因此會冒出不對的錯誤提示。
因為我目前使用 response 攔截器來攔截 401 ，因為錯誤在這邊就被攔截下來了，之後才收不到錯誤，無法跟其他錯誤在同的地方一起處理，使用 errMsg 作錯誤訊息提示。
想說開一個 errMsg context 來傳遞，但是 hook 只能在 function component 裡面使用，目前暫時讓他用 swal 回錯誤，一個折衷的作法。

因為 dylan 上次好像有提到他合進去 develop 的 code 有 bug ，不知道修好ㄌ沒有（？ 所以我就先用我上一個版本的 branch 來改動，但改動的地方不多醬子。